### PR TITLE
Remove geocode API request for Yelp location

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The ORP takes a list of given restaurants and, depending on any flags passed to 
 ## Prerequisites
 
 - Python 3.x
+- [Yelp Fusion API Key](https://docs.developer.yelp.com/docs/fusion-intro)
 
 ## Python Dependencies
 

--- a/picker.py
+++ b/picker.py
@@ -13,13 +13,15 @@ def get_location() -> str:
 
 # Yelp Fusion API has a max of 50 businesses per page that are always sorted in the same order
 # So, we're choosing a random initial starting point (offset) to select a restaurant from
-def get_random_offset_page(location: str, total: int) -> list:
+def get_random_offset_page(location: str, total_businesses: int) -> list:
     max_limit = 50
     max_businesses_per_request = 1000
     restaurants = []
 
-    if total < max_businesses_per_request:
-        random_offset = random.randrange(0, math.floor(total / max_limit) * max_limit)
+    if total_businesses < max_businesses_per_request:
+        random_offset = random.randrange(
+            0, math.floor(total_businesses / max_limit) * max_limit
+        )  # Rounding down to make sure to retrieve a complete page of businesses within the range
     else:
         random_offset = random.randrange(0, max_businesses_per_request - 1)
 

--- a/picker.py
+++ b/picker.py
@@ -1,32 +1,32 @@
+import sys
 import math
 import random
 import argparse
 import requests
 
 
-def get_lat_lon() -> int:
+def get_location() -> str:
     city = input("Please input your city: ")
     state = input("Please input your state: ")
-
-    locations = requests.get(f"https://geocode.maps.co/search?q={city}+{state}")
-
-    # Geocode passes multiple potential locations, but they place their best 'guesstimate' in the 0th index
-    lat = locations.json()[0]["lat"]
-    lon = locations.json()[0]["lon"]
-    return lat, lon
+    return (city + " " + state).replace(" ", "%")
 
 
 # Yelp Fusion API has a max of 50 businesses per page that are always sorted in the same order
 # So, we're choosing a random initial starting point (offset) to select a restaurant from
-def get_random_offset_page(lat: int, lon: int, total: int) -> list:
+def get_random_offset_page(location: str, total: int) -> list:
     max_limit = 50
+    max_businesses_per_request = 1000
     restaurants = []
 
-    random_offset = random.randrange(0, math.floor(total / max_limit) * max_limit)
-    url = f"https://api.yelp.com/v3/businesses/search?term=restaurant&latitude={lat}&longitude={lon}&offset={random_offset}"
+    if total < max_businesses_per_request:
+        random_offset = random.randrange(0, math.floor(total / max_limit) * max_limit)
+    else:
+        random_offset = random.randrange(0, max_businesses_per_request - 1)
+
+    url = f"https://api.yelp.com/v3/businesses/search?term=restaurant&location={location}&offset={random_offset}"
     headers = {
         "accept": "application/json",
-        "Authorization": "Bearer ",
+        "Authorization": "Bearer ",  # API key goes here
     }
 
     req = requests.get(url=url, headers=headers)
@@ -39,24 +39,32 @@ def get_random_offset_page(lat: int, lon: int, total: int) -> list:
     return restaurants
 
 
-def get_list_of_restaurants(lat: int, lon: int) -> int:
-    url = f"https://api.yelp.com/v3/businesses/search?term=restaurant&latitude={lat}&longitude={lon}"
+def get_list_of_restaurants(location: str) -> int:
+    url = (
+        f"https://api.yelp.com/v3/businesses/search?term=restaurant&location={location}"
+    )
     headers = {
         "accept": "application/json",
-        "Authorization": "Bearer ",
+        "Authorization": "Bearer ",  # API key goes here
     }
     r = requests.get(url=url, headers=headers)
-    total = r.json()["total"]
 
-    restaurants = get_random_offset_page(lat, lon, total)
+    try:
+        total = r.json()["total"]
+    except KeyError:
+        sys.exit(
+            "No restaurants found, check the city and state are correct for the ORP to facilitate your culinary venture."
+        )
+
+    restaurants = get_random_offset_page(location, total)
 
     return restaurants
 
 
-def get_random_restaurant(restaurants: list) -> str:
-    lat, lon = get_lat_lon()
+def get_random_restaurant() -> str:
+    location = get_location()
 
-    restaurants = get_list_of_restaurants(lat, lon)
+    restaurants = get_list_of_restaurants(location)
 
     return random.choice(restaurants)
 
@@ -78,7 +86,7 @@ def main():
     )
     args = parser.parse_args()
 
-    print(f"The ORP has chosen: {get_random_restaurant(args)}!")
+    print(f"The ORP has chosen: {get_random_restaurant()}!")
 
 
 if __name__ == "__main__":

--- a/picker.py
+++ b/picker.py
@@ -8,7 +8,7 @@ import requests
 def get_location() -> str:
     city = input("Please input your city: ")
     state = input("Please input your state: ")
-    return (city + " " + state).replace(" ", "%")
+    return (city + "%" + state).replace(" ", "%")
 
 
 # Yelp Fusion API has a max of 50 businesses per page that are always sorted in the same order


### PR DESCRIPTION
Unfortunately, the geocode API used to retrieve the latitude and longitude was slower than I wanted, so, I refactored the code to make use of Yelp's `location` query param.

Next up is to allow users to add flags to be appended onto the `GET` request as additional query params.